### PR TITLE
Fix REST default base url to match the new one

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -51,7 +51,7 @@ class Client
     /**
      * @var string
      */
-    private $baseUri = 'https://psa.valueframe.com/rest/v2/';
+    private $baseUri = 'https://rest.valueframe.com/rest/v2/';
 
     /**
      * @param string $method

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -30,7 +30,7 @@ class ClientTest extends TestCase
         $baseUri = $this->client->getClient()->getConfig('base_uri');
 
         static::assertSame('https', $baseUri->getScheme());
-        static::assertSame('psa.valueframe.com', $baseUri->getHost());
+        static::assertSame('rest.valueframe.com', $baseUri->getHost());
         static::assertSame('/rest/v2/resource', $baseUri->getPath());
     }
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -30,7 +30,7 @@ class FactoryTest extends TestCase
     {
         $client = Factory::build('customer', 'token', 'resource');
 
-        static::assertSame('https://psa.valueframe.com/rest/v2/', $client->getBaseUri());
+        static::assertSame('https://rest.valueframe.com/rest/v2/', $client->getBaseUri());
     }
 
     public function testThatClientHasCustomBaseUri()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| License       | MIT

Change the default REST base URL to match the current ValueFrame's REST base url.